### PR TITLE
Various updates: depend only on lobby-client-data, use response object for maps listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += --always-make --warn-undefined-variables
-SHELL=/bin/bash -u
-
+SHELL=/bin/bash
+.SHELLFLAGS = -eu -c
 red=\033[31m
 nc=\033[0m
 SSH_USER ?= $${USER}
@@ -11,9 +11,16 @@ help: ## Show this help text
 
 all: format check
 
+gradleProperties=$$HOME/.gradle/gradle.properties
+
 setup: ## Installs pre-commit as a pre-push git hook (requires pre-commit to be installed)
+	set -e
 	uv tool install pre-commit
 	pre-commit install --hook-type pre-push
+	test -f $(gradleProperties) || touch $(gradleProperties)
+	# Check that required gradle properties are set
+	grep -q "triplea_github_username" $(gradleProperties)
+	grep -q "triplea_github_access_token" $(gradleProperties)
 
 print-versions: ## Prints versions of system dependencies (EG: java, docker)
 	@echo -e "\n$(red)### Versions used by Gradle ###$(nc)"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Support Server
 
+
+Create file (or append to):  `~/.gradle/gradle.properties`, the following:
+
+```
+triplea_github_username=CHANGE_ME
+triplea_github_access.token=CHANGE_ME
+```
+
 ## Tech Overview
 
 - Java 21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,11 +68,10 @@ spotless {
 }
 
 val quarkusPlatformVersion = "3.34.6"
-val feignVersion = "13.6"
 val gsonVersion = "2.12.1"
 val junitVersion = "5.13.4"
 val mockitoVersion = "5.19.0"
-val tripleaVersion = "2.7.15281"
+val tripleaVersion = "2.7.15496"
 
 dependencies {
     implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:$quarkusPlatformVersion"))
@@ -99,18 +98,12 @@ dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")      // @Nonnull
 
     // TripleA shared libraries
-    implementation("triplea:domain-data:$tripleaVersion")
-    implementation("triplea:java-extras:$tripleaVersion")
-    implementation("triplea:lobby-client:$tripleaVersion")
-    implementation("triplea:websocket-client:$tripleaVersion")
+    implementation("triplea:lobby-client-data:${tripleaVersion}")
 
     // Test dependencies
     testImplementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:$quarkusPlatformVersion"))
     testImplementation("io.quarkus:quarkus-junit5")           // @QuarkusTest + Dev Services
 
-    testImplementation("io.github.openfeign:feign-core:$feignVersion")
-    testImplementation("io.github.openfeign:feign-gson:$feignVersion")
-    testImplementation("triplea:feign-common:$tripleaVersion")
 
     testImplementation("com.github.database-rider:rider-junit5:1.44.0")
     testImplementation("com.github.npathai:hamcrest-optional:2.0.0")

--- a/src/main/java/org/triplea/http/client/github/CreateIssueRequest.java
+++ b/src/main/java/org/triplea/http/client/github/CreateIssueRequest.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.triplea.java.StringUtils;
 
 /** Represents request data to create a github issue. */
 @ToString
@@ -20,11 +19,26 @@ public class CreateIssueRequest {
 
   public String getTitle() {
     final int maxLength = 125;
-    return title == null ? null : StringUtils.truncate(title, maxLength);
+    return title == null ? null : truncate(title, maxLength);
   }
 
   public String getBody() {
     final int maxLength = 65536;
-    return body == null ? null : StringUtils.truncate(body, maxLength);
+    return body == null ? null : truncate(body, maxLength);
+  }
+
+  private static String truncate(final String stringToTruncate, final int maxLength) {
+    if (maxLength < "...".length()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Illegal max length for truncate requested: %s, must be at least 3, the length of the ellipsis",
+              maxLength));
+    }
+    final String s = stringToTruncate == null ? "" : stringToTruncate;
+    if (s.length() <= maxLength) {
+      return s;
+    }
+    final String ellipsis = "...";
+    return s.substring(0, Math.max(0, maxLength - ellipsis.length())) + ellipsis;
   }
 }

--- a/src/main/java/org/triplea/io/utils/FileUtils.java
+++ b/src/main/java/org/triplea/io/utils/FileUtils.java
@@ -1,0 +1,39 @@
+package org.triplea.io.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+/** A collection of useful methods related to files. */
+@UtilityClass
+@Slf4j
+public final class FileUtils {
+
+  /**
+   * Utility to delete file specified by the given path. This method handles any needed logging if
+   * the delete fails.
+   */
+  public static void delete(final Path pathToDelete) {
+    try {
+      Files.delete(pathToDelete);
+    } catch (final IOException e) {
+      log.error("Failed to delete file: {}, {}", pathToDelete.toAbsolutePath(), e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Creates a temp file, logs and returns an empty optional if there is a problem creating the temp
+   * file.
+   */
+  public static Optional<Path> createTempFile() {
+    try {
+      return Optional.of(Files.createTempFile("triplea-temp-file", ".temp"));
+    } catch (final IOException e) {
+      log.error("Failed to create temp file: {}", e.getMessage(), e);
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/org/triplea/java/function/ThrowingFunction.java
+++ b/src/main/java/org/triplea/java/function/ThrowingFunction.java
@@ -1,0 +1,20 @@
+package org.triplea.java.function;
+
+/**
+ * A function that accepts one argument, produces a result, and may throw a checked exception.
+ *
+ * @param <T> The type of the input to the function.
+ * @param <R> The type of the result of the function.
+ * @param <E> The type of exception that may be thrown by the function.
+ */
+@FunctionalInterface
+public interface ThrowingFunction<T, R, E extends Throwable> {
+  /**
+   * Applies the function to the given argument.
+   *
+   * @param value The function argument.
+   * @return The function result.
+   * @throws E If an error occurs while applying the function.
+   */
+  R apply(T value) throws E;
+}

--- a/src/main/java/org/triplea/maps/MapsController.java
+++ b/src/main/java/org/triplea/maps/MapsController.java
@@ -11,8 +11,9 @@ import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.function.Supplier;
 import org.jdbi.v3.core.Jdbi;
-import org.triplea.http.client.maps.listing.MapDownloadItem;
-import org.triplea.http.client.maps.listing.MapsClient;
+import org.triplea.http.client.ServerPaths;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
+import org.triplea.http.client.lobby.maps.listing.MapListingResponse;
 import org.triplea.maps.listing.MapsListingModule;
 
 @Path("/")
@@ -35,8 +36,8 @@ public class MapsController {
    * maps listing', the intended audience is any game user searching for available to download maps.
    */
   @GET
-  @Path(MapsClient.MAPS_LISTING_PATH)
-  public List<MapDownloadItem> fetchAvailableMaps() {
-    return downloadListingSupplier.get();
+  @Path(ServerPaths.MAPS_LISTING_PATH)
+  public MapListingResponse fetchAvailableMaps() {
+    return MapListingResponse.builder().maps(downloadListingSupplier.get()).build();
   }
 }

--- a/src/main/java/org/triplea/maps/indexing/MapIndexingTaskRunner.java
+++ b/src/main/java/org/triplea/maps/indexing/MapIndexingTaskRunner.java
@@ -15,10 +15,6 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.http.client.github.GithubClient;
 import org.triplea.http.client.github.MapRepoListing;
-import org.triplea.java.Interruptibles;
-
-// import org.triplea.http.client.github.GithubApiClient;
-// import org.triplea.http.client.github.MapRepoListing;
 
 /**
  * Task that runs a map indexing pass on all maps. The indexing will update database to reflect the
@@ -73,7 +69,12 @@ class MapIndexingTaskRunner implements Runnable {
       IndexingResult result = index(listing);
       log.info("Indexing map: {}", listing.getUri());
       mapIndexDao.recordIndexingStatus(listing, result);
-      Interruptibles.sleep(indexingTaskDelaySeconds * 1000L);
+      try {
+        Thread.sleep(indexingTaskDelaySeconds * 1000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("System aborted, process terminated while sleeping");
+      }
     }
 
     log.info(

--- a/src/main/java/org/triplea/maps/indexing/tasks/DownloadSizeFetcher.java
+++ b/src/main/java/org/triplea/maps/indexing/tasks/DownloadSizeFetcher.java
@@ -4,6 +4,9 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -12,8 +15,7 @@ import java.util.function.Function;
 import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.io.ContentDownloader;
-import org.triplea.io.FileUtils;
+import org.triplea.io.utils.FileUtils;
 import org.triplea.java.function.ThrowingFunction;
 
 /**
@@ -24,11 +26,23 @@ import org.triplea.java.function.ThrowingFunction;
  */
 @Slf4j
 public class DownloadSizeFetcher implements Function<URI, Optional<Long>> {
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
 
   @SuppressWarnings("resource")
   @Setter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
   private ThrowingFunction<URI, InputStream, IOException> downloadFunction =
-      (uri -> new ContentDownloader(uri).getStream());
+      uri -> {
+        try {
+          HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+          HttpResponse<InputStream> response =
+              HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
+          return response.body();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Download interrupted", e);
+        }
+      };
 
   @Override
   public Optional<Long> apply(URI uri) {

--- a/src/main/java/org/triplea/maps/indexing/tasks/MapDescriptionReader.java
+++ b/src/main/java/org/triplea/maps/indexing/tasks/MapDescriptionReader.java
@@ -1,10 +1,13 @@
 package org.triplea.maps.indexing.tasks;
 
+import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Optional;
 import java.util.function.Function;
 import org.triplea.http.client.github.MapRepoListing;
-import org.triplea.io.ContentDownloader;
 
 /**
  * A function where if given a map repo listing will find the 'description.html' file in that repo
@@ -13,6 +16,8 @@ import org.triplea.io.ContentDownloader;
  */
 public class MapDescriptionReader implements Function<MapRepoListing, String> {
   private static final int DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH = 3000;
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
 
   @Override
   public String apply(final MapRepoListing mapRepoListing) {
@@ -34,8 +39,18 @@ public class MapDescriptionReader implements Function<MapRepoListing, String> {
   }
 
   private Optional<String> downloadDescription(final MapRepoListing mapRepoListing) {
-    final String descriptionUri =
-        mapRepoListing.getUri().toString() + "/blob/master/description.html?raw=true";
-    return ContentDownloader.downloadAsString(URI.create(descriptionUri));
+    final URI descriptionUri =
+        URI.create(mapRepoListing.getUri().toString() + "/blob/master/description.html?raw=true");
+    try {
+      HttpRequest request = HttpRequest.newBuilder(descriptionUri).GET().build();
+      HttpResponse<String> response =
+          HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      return response.statusCode() == 200 ? Optional.of(response.body()) : Optional.empty();
+    } catch (IOException e) {
+      return Optional.empty();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return Optional.empty();
+    }
   }
 }

--- a/src/main/java/org/triplea/maps/indexing/tasks/MapNameReader.java
+++ b/src/main/java/org/triplea/maps/indexing/tasks/MapNameReader.java
@@ -1,7 +1,11 @@
 package org.triplea.maps.indexing.tasks;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -10,17 +14,31 @@ import lombok.Builder;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.http.client.github.MapRepoListing;
-import org.triplea.io.ContentDownloader;
 import org.triplea.yaml.YamlReader;
 
 @Slf4j
 @Builder
 public class MapNameReader implements Function<MapRepoListing, Optional<String>> {
-  /* Function to download content as a string and log an info message if not found. */
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+
+  /* Function to download content as a string, returns null if the download fails or returns a non-200 status. */
   @Setter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
   @Builder.Default
   private Function<URI, String> downloadFunction =
-      uri -> ContentDownloader.downloadAsString(uri).orElse(null);
+      uri -> {
+        try {
+          HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+          HttpResponse<String> response =
+              HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+          return response.statusCode() == 200 ? response.body() : null;
+        } catch (IOException e) {
+          return null;
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return null;
+        }
+      };
 
   public static URI computeMapYamlLocation(MapRepoListing mapRepoListing) {
     return URI.create(mapRepoListing.getUri().toString() + "/blob/master/map.yml?raw=true");

--- a/src/main/java/org/triplea/maps/listing/MapListingDao.java
+++ b/src/main/java/org/triplea/maps/listing/MapListingDao.java
@@ -5,8 +5,8 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.reflect.BeanMapper;
-import org.triplea.http.client.maps.listing.MapDownloadItem;
-import org.triplea.http.client.maps.listing.MapTag;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
+import org.triplea.http.client.lobby.maps.listing.MapTag;
 
 @AllArgsConstructor
 public class MapListingDao {

--- a/src/main/java/org/triplea/maps/listing/MapListingRecord.java
+++ b/src/main/java/org/triplea/maps/listing/MapListingRecord.java
@@ -8,8 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
-import org.triplea.http.client.maps.listing.MapDownloadItem;
-import org.triplea.http.client.maps.listing.MapTag;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
+import org.triplea.http.client.lobby.maps.listing.MapTag;
 
 @Setter
 @Getter

--- a/src/main/java/org/triplea/maps/listing/MapsListingModule.java
+++ b/src/main/java/org/triplea/maps/listing/MapsListingModule.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import org.jdbi.v3.core.Jdbi;
-import org.triplea.http.client.maps.listing.MapDownloadItem;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
 
 @AllArgsConstructor
 public class MapsListingModule implements Supplier<List<MapDownloadItem>> {

--- a/src/main/java/org/triplea/server/error/reporting/ErrorReportController.java
+++ b/src/main/java/org/triplea/server/error/reporting/ErrorReportController.java
@@ -14,10 +14,10 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jdbi.v3.core.Jdbi;
-import org.triplea.http.client.ClientIdentifiers;
+import org.triplea.http.client.HttpHeaders;
+import org.triplea.http.client.ServerPaths;
 import org.triplea.http.client.error.report.CanUploadErrorReportResponse;
 import org.triplea.http.client.error.report.CanUploadRequest;
-import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.http.client.error.report.ErrorReportResponse;
 import org.triplea.http.client.github.GithubClient;
@@ -55,7 +55,7 @@ public class ErrorReportController {
   }
 
   @POST
-  @Path(ErrorReportClient.CAN_UPLOAD_ERROR_REPORT_PATH)
+  @Path(ServerPaths.CAN_UPLOAD_ERROR_REPORT_PATH)
   public CanUploadErrorReportResponse canUploadErrorReport(CanUploadRequest canUploadRequest) {
     if (canUploadRequest == null
         || canUploadRequest.getErrorTitle() == null
@@ -70,7 +70,7 @@ public class ErrorReportController {
    * user to in turn create a GitHub issue using the data from the error report.
    */
   @POST
-  @Path(ErrorReportClient.ERROR_REPORT_PATH)
+  @Path(ServerPaths.ERROR_REPORT_PATH)
   public ErrorReportResponse uploadErrorReport(
       @Context HttpServletRequest request, ErrorReportRequest errorReport) {
 
@@ -84,7 +84,7 @@ public class ErrorReportController {
     return errorReportIngestion.createErrorReport(
         CreateIssueParams.builder()
             .ip(IpAddressExtractor.extractIpAddress(request))
-            .systemId(request.getHeader(ClientIdentifiers.VERSION_HEADER))
+            .systemId(request.getHeader(HttpHeaders.VERSION_HEADER))
             .errorReportRequest(errorReport)
             .build());
   }

--- a/src/main/java/org/triplea/yaml/YamlReader.java
+++ b/src/main/java/org/triplea/yaml/YamlReader.java
@@ -1,0 +1,96 @@
+package org.triplea.yaml;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.experimental.UtilityClass;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
+
+/** Methods useful for reading YAML data from a String or InputStream. */
+@UtilityClass
+public class YamlReader {
+  /**
+   * Reads from input a YAML data structure. YAML is assumed to be a List at the top level.
+   *
+   * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
+   */
+  @SuppressWarnings("unchecked")
+  public static List<Map<String, Object>> readList(final String input) {
+    try {
+      return (List<Map<String, Object>>) readYaml(asStream(input));
+    } catch (final YamlEngineException | ClassCastException e) {
+      throw new InvalidYamlFormatException(e);
+    }
+  }
+
+  /**
+   * Reads from input a YAML data structure. YAML is assumed to be a List at the top level.
+   *
+   * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
+   */
+  @SuppressWarnings("unchecked")
+  public static List<Map<String, Object>> readList(final InputStream input) {
+    try {
+      return (List<Map<String, Object>>) readYaml(input);
+    } catch (final YamlEngineException | ClassCastException e) {
+      throw new InvalidYamlFormatException(e);
+    }
+  }
+
+  /**
+   * Reads from input a YAML data structure. YAML is assumed to be map at the top level.
+   *
+   * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
+   */
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> readMap(final String input) {
+    try {
+      return (Map<String, Object>) readYaml(asStream(input));
+    } catch (final YamlEngineException | ClassCastException e) {
+      throw new InvalidYamlFormatException(e);
+    }
+  }
+
+  /**
+   * Reads from input a YAML data structure. YAML is assumed to be map at the top level.
+   *
+   * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
+   */
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> readMap(final InputStream input) {
+    try {
+      return (Map<String, Object>) readYaml(input);
+    } catch (final YamlEngineException | ClassCastException e) {
+      throw new InvalidYamlFormatException(e);
+    }
+  }
+
+  private static InputStream asStream(final String inputString) {
+    return new ByteArrayInputStream(
+        (inputString == null ? "" : inputString).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static Object readYaml(final InputStream inputStream) {
+    final Load load = new Load(LoadSettings.builder().build());
+    final var result = load.loadFromInputStream(inputStream);
+    return Optional.ofNullable(result)
+        .orElseThrow(() -> new InvalidYamlFormatException("Unable to read yaml data"));
+  }
+
+  public static class InvalidYamlFormatException extends RuntimeException {
+    private static final long serialVersionUID = -1920143388576824621L;
+
+    public InvalidYamlFormatException(final String message) {
+      super(message);
+    }
+
+    public InvalidYamlFormatException(final Exception e) {
+      super("Invalid yaml format: " + e.getMessage(), e);
+    }
+  }
+}

--- a/src/testInteg/java/org/triplea/error/reporting/ErrorReportControllerIntegrationTest.java
+++ b/src/testInteg/java/org/triplea/error/reporting/ErrorReportControllerIntegrationTest.java
@@ -4,16 +4,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
+import com.google.gson.Gson;
 import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.http.client.LobbyHttpClientConfig;
+import org.triplea.http.client.HttpHeaders;
+import org.triplea.http.client.ServerPaths;
 import org.triplea.http.client.error.report.CanUploadRequest;
-import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.http.client.error.report.ErrorReportResponse;
 import org.triplea.maps.IntegTestExtension;
@@ -21,35 +26,58 @@ import org.triplea.maps.IntegTestExtension;
 @QuarkusTest
 @ExtendWith(IntegTestExtension.class)
 class ErrorReportControllerIntegrationTest {
-  private ErrorReportClient client;
+  private static final Gson GSON = new Gson();
+
+  private HttpClient httpClient;
+  private String baseUrl;
 
   @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
   int testPort;
 
   @BeforeEach
   void setUp() {
-    LobbyHttpClientConfig.setConfig(
-        LobbyHttpClientConfig.builder().systemId("test-system-id").clientVersion("test").build());
-    client = ErrorReportClient.newClient(URI.create("http://localhost:" + testPort));
+    httpClient = HttpClient.newHttpClient();
+    baseUrl = "http://localhost:" + testPort;
   }
 
   @Disabled
   @Test
-  void uploadErrorReport() {
-    final ErrorReportResponse response =
-        client.uploadErrorReport(
-            ErrorReportRequest.builder()
-                .body("body")
-                .title("error-report-title-" + String.valueOf(Math.random()).substring(0, 10))
-                .gameVersion("version")
-                .build());
+  void uploadErrorReport() throws IOException, InterruptedException {
+    var requestBody =
+        ErrorReportRequest.builder()
+            .body("body")
+            .title("error-report-title-" + String.valueOf(Math.random()).substring(0, 10))
+            .gameVersion("version")
+            .build();
 
-    assertThat(response.getGithubIssueLink(), is(notNullValue()));
+    var httpRequest =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + ServerPaths.ERROR_REPORT_PATH))
+            .header("Content-Type", "application/json")
+            .header(HttpHeaders.SYSTEM_ID_HEADER, "test-system-id")
+            .header(HttpHeaders.VERSION_HEADER, "test")
+            .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(requestBody)))
+            .build();
+
+    var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+    var errorReportResponse = GSON.fromJson(response.body(), ErrorReportResponse.class);
+
+    assertThat(errorReportResponse.getGithubIssueLink(), is(notNullValue()));
   }
 
   @Test
-  void canUploadErrorReport() {
-    client.canUploadErrorReport(
-        CanUploadRequest.builder().gameVersion("2.0").errorTitle("title").build());
+  void canUploadErrorReport() throws IOException, InterruptedException {
+    var requestBody = CanUploadRequest.builder().gameVersion("2.0").errorTitle("title").build();
+
+    var httpRequest =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + ServerPaths.CAN_UPLOAD_ERROR_REPORT_PATH))
+            .header("Content-Type", "application/json")
+            .header(HttpHeaders.SYSTEM_ID_HEADER, "test-system-id")
+            .header(HttpHeaders.VERSION_HEADER, "test")
+            .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(requestBody)))
+            .build();
+
+    httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
   }
 }

--- a/src/testInteg/java/org/triplea/maps/listing/MapListingCharacterizationTest.java
+++ b/src/testInteg/java/org/triplea/maps/listing/MapListingCharacterizationTest.java
@@ -4,16 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.junit5.DBUnitExtension;
+import com.google.gson.Gson;
 import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.http.client.ClientIdentifiers;
-import org.triplea.http.client.maps.listing.MapDownloadItem;
-import org.triplea.http.client.maps.listing.MapsClient;
+import org.triplea.http.client.HttpHeaders;
+import org.triplea.http.client.ServerPaths;
+import org.triplea.http.client.lobby.maps.listing.MapDownloadItem;
+import org.triplea.http.client.lobby.maps.listing.MapListingResponse;
 import org.triplea.maps.IntegTestExtension;
 
 /**
@@ -30,26 +36,31 @@ import org.triplea.maps.IntegTestExtension;
 @ExtendWith(IntegTestExtension.class)
 @ExtendWith(DBUnitExtension.class)
 class MapListingCharacterizationTest {
+  private static final Gson GSON = new Gson();
+
   @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
   int testPort;
 
-  private MapsClient mapsClient;
+  private HttpClient httpClient;
 
   @BeforeEach
   void setUp() {
-    mapsClient =
-        MapsClient.newClient(
-            URI.create("http://localhost:" + testPort),
-            ClientIdentifiers.builder()
-                .applicationVersion("test")
-                .systemId("test")
-                .apiKey("")
-                .build());
+    httpClient = HttpClient.newHttpClient();
   }
 
   @Test
-  void mapsListingMatchesProdSample() {
-    final List<MapDownloadItem> results = mapsClient.fetchMapListing();
+  void mapsListingMatchesProdSample() throws IOException, InterruptedException {
+    var httpRequest =
+        HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:" + testPort + ServerPaths.MAPS_LISTING_PATH))
+            .header(HttpHeaders.SYSTEM_ID_HEADER, "test")
+            .header(HttpHeaders.VERSION_HEADER, "test")
+            .GET()
+            .build();
+
+    var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+    final List<MapDownloadItem> results =
+        GSON.fromJson(response.body(), MapListingResponse.class).getMaps();
 
     assertThat(results)
         .hasSize(20)

--- a/src/testInteg/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/src/testInteg/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.http.client.maps.listing.MapTag;
+import org.triplea.http.client.lobby.maps.listing.MapTag;
 import org.triplea.maps.DbOnlyExtension;
 
 @DataSet(value = "map_index.yml,map_tag_value.yml", useSequenceFiltering = false)


### PR DESCRIPTION
- Removes dependencies on java-extras and everything from triplea game client other than 'lobby-client-data'. This helps remove transitive dependencies
- Update maps listing endoint to return a response object instead of a raw list